### PR TITLE
Handle non-ascii subjects in log

### DIFF
--- a/Ui/Component/Listing/Column/ViewAction.php
+++ b/Ui/Component/Listing/Column/ViewAction.php
@@ -77,6 +77,7 @@ class ViewAction extends Column
 	{
 		if (isset($dataSource['data']['items'])) {
 			foreach ($dataSource['data']['items'] as & $item) {
+				$item['subject'] = iconv_mime_decode($item['subject'], 0, 'UTF-8');
 				$name = $this->getData('name');
 				if (isset($item['id'])) {
 					$item[$name]['view'] = [


### PR DESCRIPTION
Emails subjects with non-ascii characters were not shown correctly in the log grid:
![smtp-before](https://user-images.githubusercontent.com/266474/31501224-f1086a44-af69-11e7-91f9-90179ce3a97c.png)

By decoding the subject with function [iconv_mime_decode](http://php.net/manual/en/function.iconv-mime-decode.php) to UTF-8, it works correctly:

![smtp-after](https://user-images.githubusercontent.com/266474/31501289-1b1b9db0-af6a-11e7-9ede-5198c6bda71a.png)

See also: https://ncona.com/2011/06/using-utf-8-characters-on-an-e-mail-subject/