### PR TITLE
Support Magento 2.2

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,8 +21,14 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- for Magento version < 2.2 -->
     <type name="Magento\Framework\Mail\Transport">
         <plugin name="Mageplaza_Smtp_Plugin_Magento_Framework_Mail_Transport" sortOrder="10" type="Mageplaza\Smtp\Plugin\Magento\Framework\Mail\Transport"/>
+    </type>
+
+    <!-- for Magento version >= 2.2 -->
+    <type name="Magento\Framework\Mail\TransportInterface">
+        <plugin name="Mageplaza_Smtp_Plugin_Magento_Framework_Mail_TransportInterface" sortOrder="10" type="Mageplaza\Smtp\Plugin\Magento\Framework\Mail\Transport"/>
     </type>
 
     <type name="Magento\Framework\Mail\Message">


### PR DESCRIPTION
Not tested, but maybe overwriting only type `Magento\Framework\Mail\TransportInterface` would also work for Magento <= 2.1.

Closes #12 