### PR TITLE
Fix 'none' protocol (also fixes autofills that use 'none')

### DIFF
--- a/Model/Config/Source/Protocol.php
+++ b/Model/Config/Source/Protocol.php
@@ -38,7 +38,7 @@ class Protocol implements ArrayInterface
     {
         $options = [
             [
-                'value' => 'none',
+                'value' => '',
                 'label' => __('None')
             ],
             [


### PR DESCRIPTION
'Mageplaza\Smtp\Mail\Rse\Mail' doesn't account for 'none', change the option value itself to '<blank>' to allow the Mail class to properly not use a protocol. All of the autofills also try to set to '<blank>', so this also fixes those autofills.