### PR TITLE
Fix email sending without ssl

### DIFF
--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -89,7 +89,7 @@ class Mail extends \Zend_Application_Resource_Mail
             $this->_smtpOptions[$storeId] = [
                 'type' => 'smtp',
                 'host' => isset($configData['host']) ? $configData['host'] : '',
-                'ssl' => isset($configData['protocol']) ? $configData['protocol'] : '',
+                'ssl' => isset($configData['protocol']) ? $configData['protocol'] : null,
                 'port' => isset($configData['port']) ? $configData['port'] : '',
                 'auth' => isset($configData['authentication']) ? $configData['authentication'] : '',
                 'username' => isset($configData['username']) ? $configData['username'] : '',


### PR DESCRIPTION
Without this change we got an `Zend_Mail_Protocol_Exception` exception

![default](https://user-images.githubusercontent.com/191082/37847659-40e34f8a-2eda-11e8-9071-5112505b1087.png)


```php
class Zend_Mail_Protocol_Smtp {
    public function __construct($host = '127.0.0.1', $port = null, array $config = array())
    {
        if (isset($config['ssl'])) { // true for empty string
            switch (strtolower($config['ssl'])) {
                case 'tls':
                    $this->_secure = 'tls';
                    break;

                case 'ssl':
                    $this->_transport = 'ssl';
                    $this->_secure = 'ssl';
                    if ($port == null) {
                        $port = 465;
                    }
                    break;

                default: // empty string goes here
                    throw new Zend_Mail_Protocol_Exception($config['ssl'] . ' is unsupported SSL type');
                    break;
            }
        }
```