### PR TITLE
In Emails log grid, decode also to "from" and "to" columns.

### DIFF
--- a/Ui/Component/Listing/Column/Actions.php
+++ b/Ui/Component/Listing/Column/Actions.php
@@ -69,6 +69,8 @@ class Actions extends Column
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $item['subject'] = iconv_mime_decode($item['subject'], 2, 'UTF-8');
+                $item['from'] = iconv_mime_decode($item['from'], 2, 'UTF-8');
+                $item['to']   = iconv_mime_decode($item['to'], 2, 'UTF-8');
 
                 $item[$this->getData('name')] = [
                     'view'   => [


### PR DESCRIPTION
Hello.
Thank you for creating a good extension.

It is conceivable that characters other than ASCII are included in "from" and "to", and in fact, it is commonplace in my Japanese language sphere.
So, in Emails log Grid, I added a process to decode it like "subject".

Thank you.