### PR TITLE
Add required title to attribute Mageplaza_Core::menu. Tested in MG 2.2.5

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -23,7 +23,7 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                <resource id="Mageplaza_Core::menu">
+                <resource id="Mageplaza_Core::menu" title="Mageplaza" translate="title">
                     <resource id="Mageplaza_Smtp::smtp" title="Mageplaza Smtp" translate="title" sortOrder="45">
                         <resource id="Mageplaza_Smtp::log" title="Emails Log" translate="title" sortOrder="10"/>
                     </resource>


### PR DESCRIPTION
If the attribute title is missing in new resources,  the setup:upgrade command fails giving a message:

**Element 'resource': The attribute 'title' is required but missing.**

Tested in Magento 2.2.5