### PR TITLE
Update Authentication.php

### DIFF
--- a/Model/Config/Source/Authentication.php
+++ b/Model/Config/Source/Authentication.php
@@ -38,7 +38,7 @@ class Authentication implements ArrayInterface
     {
         $options = [
             [
-                'value' => '',
+                'value' => 'smtp',
                 'label' => __('NONE')
             ],
             [


### PR DESCRIPTION
Fix Authentication "none" - value-string is used as connection-class in zend-mail and thus needs to be `smtp`