### PR TITLE
issues-185: Fix Resend Email error with `recipient` is mail address only. No name on bracket

### DIFF
--- a/Model/Log.php
+++ b/Model/Log.php
@@ -274,6 +274,8 @@ class Log extends AbstractModel
                         $email = trim($emailArray[1], '<>');
                     }
                     $data[$name] = $email;
+                } else {
+                    $data[] = $email;
                 }
             }
         }


### PR DESCRIPTION


### Description
Fix Resend Email error with `recipient` is mail address only. No name on bracket

### Fixed Issues (if relevant)

**[mageplaza/magento-2-smtp#185](https://github.com/mageplaza/magento-2-smtp/issues/185): Resend Email error with `recipient` is mail address only. No name**
