### PR TITLE
Obtains a collection with only the IDs.

### DIFF
--- a/Cron/ClearLog.php
+++ b/Cron/ClearLog.php
@@ -91,7 +91,8 @@ class ClearLog
 
             /** @var Collection $logs */
             $logs = $this->collectionLog->create()
-                ->addFieldToFilter('created_at', ['lteq' => date('Y-m-d H:i:s', $timeEnd)]);
+                ->addFieldToFilter('created_at', ['lteq' => date('Y-m-d H:i:s', $timeEnd)])
+                ->addFieldToSelect([]);
 
             foreach ($logs as $log) {
                 try {


### PR DESCRIPTION
### Description (*)
This avoids high memory consumption when there are many items in the log.
