### PR TITLE
Add dependencies in etc/module.xml

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -22,6 +22,12 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Mageplaza_Smtp" setup_version="1.2.4">
         <sequence>
+            <module name="Magento_Config"/>
+            <module name="Magento_Customer"/>
+            <module name="Magento_Eav"/>
+            <module name="Magento_Quote"/>
+            <module name="Magento_Newsletter"/>
+            <module name="Magento_Sales"/>
             <module name="Mageplaza_Core"/>
         </sequence>
     </module>


### PR DESCRIPTION
Should fix mageplaza/magento-2-smtp#309

### Description (*)
Add dependencies in etc/module.xml
Required to install the module before calling `bin/magento setup:install`

### Fixed Issues (if relevant)
1. Fixes mageplaza/magento-2-smtp#309

### Manual testing scenarios (*)
1. Call `composer require mageplaza/magento-2-smtp`
2. Then call `bin/magento setup:install`
