### PR TITLE
fix: if no active quote is found error is thrown

### DIFF
--- a/Plugin/AccountManagement.php
+++ b/Plugin/AccountManagement.php
@@ -77,11 +77,12 @@ class AccountManagement
             return $result;
         }
 
-        /** @var Quote $quote */
-        $quote = $this->cartRepository->getActive($cartId);
-        $quote->setCustomerEmail($customerEmail);
-
         try {
+
+            /** @var Quote $quote */
+            $quote = $this->cartRepository->getActive($cartId);
+            $quote->setCustomerEmail($customerEmail);
+
             $this->cartRepository->save($quote);
 
             return $result;


### PR DESCRIPTION
 if no active quote is found error is thrown, order placement is stopped , no redirect to success page is possible

<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

If in combination of plugins some other process deactivates the quote before this plugin reacts this module will break checkout process with error "No Such Entity With Cart ID " and user is redirected to empty cart page.

simplest solution is to place the quote search to try/catch if it fails it fails silently. If this is a important feature other methods for searching quote need to be used 

