### PR TITLE
Store transport per store to prevent possible conflicting SMTP options

### DIFF
--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -70,14 +70,16 @@ class Mail
     protected $_returnPath = [];
 
     /**
-     * @var Zend_Mail_Transport_Smtp
-     */
-    protected $_transport;
-
-    /**
      * @var array
      */
     protected $_fromByStore = [];
+
+    /**
+     * Placeholder for store specific transports.
+     *
+     * @var Zend_Mail_Transport_Smtp[]|Smtp[]
+     */
+    protected $_transportsByStore = [];
 
     /**
      * Mail constructor.
@@ -119,69 +121,82 @@ class Mail
         return $this;
     }
 
+
+    /**
+     * @param $storeId
+     *
+     * @return Zend_Mail_Transport_Smtp | Smtp
+     */
+    public function getTransport($storeId)
+    {
+        if (!array_key_exists($storeId, $this->_transportsByStore)) {
+            $this->_transportsByStore[$storeId] = $this->createTransportForStore($storeId);
+        }
+
+        return $this->_transportsByStore[$storeId];
+    }
+
     /**
      * @param $storeId
      *
      * @return Zend_Mail_Transport_Smtp | Smtp
      * @throws Zend_Exception
      */
-    public function getTransport($storeId)
-    {
-        if ($this->_transport === null) {
-            if (!isset($this->_smtpOptions[$storeId])) {
-                $configData = $this->smtpHelper->getSmtpConfig('', $storeId);
-                $options    = [
-                    'host' => isset($configData['host']) ? $configData['host'] : '',
-                    'port' => isset($configData['port']) ? $configData['port'] : ''
+    protected function createTransportForStore($storeId)
+{
+        if (!isset($this->_smtpOptions[$storeId])) {
+            $configData = $this->smtpHelper->getSmtpConfig('', $storeId);
+            $options    = [
+                'host' => isset($configData['host']) ? $configData['host'] : '',
+                'port' => isset($configData['port']) ? $configData['port'] : ''
+            ];
+
+            if (isset($configData['authentication']) && $configData['authentication'] !== "") {
+                $options += [
+                    'auth'     => $configData['authentication'],
+                    'username' => isset($configData['username']) ? $configData['username'] : '',
+                    'password' => $this->smtpHelper->getPassword($storeId)
                 ];
-
-                if (isset($configData['authentication']) && $configData['authentication'] !== "") {
-                    $options += [
-                        'auth'     => $configData['authentication'],
-                        'username' => isset($configData['username']) ? $configData['username'] : '',
-                        'password' => $this->smtpHelper->getPassword($storeId)
-                    ];
-                }
-
-                if (isset($configData['protocol']) && $configData['protocol'] !== "") {
-                    $options['ssl'] = $configData['protocol'];
-                }
-
-                $this->_smtpOptions[$storeId] = $options;
             }
 
-            if (!isset($this->_smtpOptions[$storeId]['host']) || !$this->_smtpOptions[$storeId]['host']) {
-                throw new Zend_Exception(__('A host is necessary for smtp transport, but none was given'));
+            if (isset($configData['protocol']) && $configData['protocol'] !== "") {
+                $options['ssl'] = $configData['protocol'];
             }
 
-            if ($this->smtpHelper->versionCompare('2.2.8')) {
-                $options = $this->_smtpOptions[$storeId];
-                if (isset($options['auth'])) {
-                    $options['connection_class']  = $options['auth'];
-                    $options['connection_config'] = [
-                        'username' => $options['username'],
-                        'password' => $options['password']
-                    ];
-                    unset($options['auth'], $options['username'], $options['password']);
-                }
-                if (isset($options['ssl'])) {
-                    $options['connection_config']['ssl'] = $options['ssl'];
-                    unset($options['ssl']);
-                }
-                unset($options['type']);
-
-                $options = new SmtpOptions($options);
-
-                $this->_transport = new Smtp($options);
-            } else {
-                $this->_transport = new Zend_Mail_Transport_Smtp(
-                    $this->_smtpOptions[$storeId]['host'],
-                    $this->_smtpOptions[$storeId]
-                );
-            }
+            $this->_smtpOptions[$storeId] = $options;
         }
 
-        return $this->_transport;
+        if (!isset($this->_smtpOptions[$storeId]['host']) || !$this->_smtpOptions[$storeId]['host']) {
+            throw new Zend_Exception(__('A host is necessary for smtp transport, but none was given'));
+        }
+
+        if ($this->smtpHelper->versionCompare('2.2.8')) {
+            $options = $this->_smtpOptions[$storeId];
+            if (isset($options['auth'])) {
+                $options['connection_class']  = $options['auth'];
+                $options['connection_config'] = [
+                    'username' => $options['username'],
+                    'password' => $options['password']
+                ];
+                unset($options['auth'], $options['username'], $options['password']);
+            }
+            if (isset($options['ssl'])) {
+                $options['connection_config']['ssl'] = $options['ssl'];
+                unset($options['ssl']);
+            }
+            unset($options['type']);
+
+            $options = new SmtpOptions($options);
+
+            $transport = new Smtp($options);
+        } else {
+            $transport = new Zend_Mail_Transport_Smtp(
+                $this->_smtpOptions[$storeId]['host'],
+                $this->_smtpOptions[$storeId]
+            );
+        }
+
+        return $transport;
     }
 
     /**

--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -121,7 +121,6 @@ class Mail
         return $this;
     }
 
-
     /**
      * @param $storeId
      *
@@ -143,7 +142,7 @@ class Mail
      * @throws Zend_Exception
      */
     protected function createTransportForStore($storeId)
-{
+    {
         if (!isset($this->_smtpOptions[$storeId])) {
             $configData = $this->smtpHelper->getSmtpConfig('', $storeId);
             $options    = [


### PR DESCRIPTION
### Description (*)

This pull requests implements the store specific transports, as related to https://github.com/mageplaza/magento-2-smtp/issues/330

With `asynchronous sending` enabled and knowing that in our multi-store installation we have separate SMTP settings for each store, we noticed that the wrong SMTP settings were being used (wrong host, username, password) if in a single batch (the cronjob that is used for asynchronous sending) order confirmation emails existed from more than one store.

This seems to happen because although `Mageplaza\Smtp\Mail\Rse::getTransport` receives the `storeId`, it only creates a new `Transport` instance (with the correct SMTP options of the first shop) the first time it is called, instead of the first time per store.

This PR simply adds similar behaviour for the transport instances, as already exists for other variables in this class. With this change, we could verify that each confirmation email used the correct SMTP settings, even if we had multiple stores in a single run.


### Fixed Issues (if relevant)
1. Fixes mageplaza/magento-2-smtp#330

### Manual testing scenarios (*)
1. Setup multiple stores, each with different SMTP options (for example, distinct usernames)
2. Force multiple order confirmation within one minute, where the order come from different stores.
3. Verify that each order is actually send out with the correct SMTP options

### Questions or comments

This change solved the incorrect behaviour in our installation. We are not aware of any side effects, especially since in most times, only a single store will be present in a batch.

