### PR TITLE
Do not change the result within CustomerAccountManagement::isEmailAvailable() plugin

### DIFF
--- a/Plugin/AccountManagement.php
+++ b/Plugin/AccountManagement.php
@@ -86,7 +86,7 @@ class AccountManagement
 
             return $result;
         } catch (Exception $e) {
-            return false;
+            return $result;
         }
     }
 }


### PR DESCRIPTION
### Description
If an error occurs within this plugin, it will not change the availability of an email address and therefore should not change the result of calling `Magento\Customer\Model\AccountManagement::isEmailAvailable()`

### Related Pull Requests
- #329
- #324

### Fixed Issues
- This is related to (but does not fix) #315

### Manual testing scenarios
See #315 for details.