### PR TITLE
perf: Index mageplaza_smtp_log.created_at used in ORDER BY clause

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -253,6 +253,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
             ]);
         }
 
+        if (version_compare($context->getVersion(), '1.2.6', '<')) {
+            $connection->addIndex($setup->getTable("mageplaza_smtp_log"), "idx_created_at", "created_at");
+        }
+
         $setup->endSetup();
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -20,7 +20,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mageplaza_Smtp" setup_version="1.2.5">
+    <module name="Mageplaza_Smtp" setup_version="1.2.6">
         <sequence>
             <module name="Mageplaza_Core"/>
             <module name="Magento_Customer"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

We add an index to the `mageplaza_smtp_log` table on the `created_at` field. This improves the performance of SMTP Log page
as described in issue https://github.com/mageplaza/magento-2-smtp/issues/368

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes mageplaza/magento-2-smtp#368

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Prior to applying this PR open the STMP log page with about 200 and see how long it takes
2. Then apply this PR and open the same STMP log page and notice how it was quicker now

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

