### PR TITLE
#309 Fixed error "Invalid entity_type specified: customer", when installing magento project

### DIFF
--- a/Plugin/AccountManagement.php
+++ b/Plugin/AccountManagement.php
@@ -78,7 +78,7 @@ class AccountManagement
         }
 
         /** @var Quote $quote */
-        $quote = $this->cartRepository->getActive($cartId);
+        $quote = $this->cartRepository->get($cartId);
         $quote->setCustomerEmail($customerEmail);
 
         try {

--- a/Plugin/AccountManagement.php
+++ b/Plugin/AccountManagement.php
@@ -77,16 +77,15 @@ class AccountManagement
             return $result;
         }
 
-        /** @var Quote $quote */
-        $quote = $this->cartRepository->get($cartId);
-        $quote->setCustomerEmail($customerEmail);
-
         try {
+            /** @var Quote $quote */
+            $quote = $this->cartRepository->get($cartId);
+            $quote->setCustomerEmail($customerEmail);
+            
             $this->cartRepository->save($quote);
-
-            return $result;
         } catch (Exception $e) {
-            return false;
         }
+        
+        return $result;
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -27,7 +27,6 @@ use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
 use Magento\Sales\Model\ResourceModel\Order as OrderResource;
-use Magento\Customer\Model\ResourceModel\Customer as CustomerResource;
 use Magento\Newsletter\Model\ResourceModel\Subscriber as SubscriberResource;
 use Zend_Db_Exception;
 
@@ -48,11 +47,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
     protected $orderResource;
 
     /**
-     * @var CustomerResource
-     */
-    protected $customerResource;
-
-    /**
      * @var SubscriberResource
      */
     protected $subscriberResource;
@@ -62,18 +56,15 @@ class UpgradeSchema implements UpgradeSchemaInterface
      *
      * @param QuoteResource $quoteResource
      * @param OrderResource $orderResource
-     * @param CustomerResource $customerResource
      * @param SubscriberResource $subscriberResource
      */
     public function __construct(
         QuoteResource $quoteResource,
         OrderResource $orderResource,
-        CustomerResource $customerResource,
         SubscriberResource $subscriberResource
     ) {
         $this->quoteResource      = $quoteResource;
         $this->orderResource      = $orderResource;
-        $this->customerResource   = $customerResource;
         $this->subscriberResource = $subscriberResource;
     }
 
@@ -227,8 +218,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'comment'  => 'Mp SMTP Email Marketing synced'
             ];
 
-            $customerConnection = $this->customerResource->getConnection();
-            $customerConnection->addColumn(
+            $setup->getConnection()->addColumn(
                 $setup->getTable('customer_entity'),
                 'mp_smtp_email_marketing_synced',
                 $column


### PR DESCRIPTION
### Description (*)

When installing Magento 2.4.x with `bin/magento setup:install` the installation fails with

![2022-07-29_10-34-22](https://user-images.githubusercontent.com/325244/181708636-2dbe498d-1fac-430b-a2c1-8563babc4839.png)

### Related Pull Requests

1. https://github.com/mageplaza/magento-2-smtp/pull/355
2. https://github.com/mageplaza/magento-2-smtp/pull/357

### Fixed Issues (if relevant)

1. Fixes mageplaza/magento-2-smtp#309

### Manual testing scenarios (*)

1. Run `bin/magento setup:install` on empty database

