### PR TITLE
Fixed bug where transport object is reused across stores containing wrong authentication info

### DIFF
--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -127,7 +127,7 @@ class Mail
      */
     public function getTransport($storeId)
     {
-        if ($this->_transport[$storeId] === null) {
+        if (!isset($this->_transport[$storeId])) {
             if (!isset($this->_smtpOptions[$storeId])) {
                 $configData = $this->smtpHelper->getSmtpConfig('', $storeId);
                 $options    = [

--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -70,9 +70,9 @@ class Mail
     protected $_returnPath = [];
 
     /**
-     * @var Zend_Mail_Transport_Smtp
+     * @var array Zend_Mail_Transport_Smtp
      */
-    protected $_transport;
+    protected $_transport = [];
 
     /**
      * @var array
@@ -127,7 +127,7 @@ class Mail
      */
     public function getTransport($storeId)
     {
-        if ($this->_transport === null) {
+        if ($this->_transport[$storeId] === null) {
             if (!isset($this->_smtpOptions[$storeId])) {
                 $configData = $this->smtpHelper->getSmtpConfig('', $storeId);
                 $options    = [
@@ -172,16 +172,16 @@ class Mail
 
                 $options = new SmtpOptions($options);
 
-                $this->_transport = new Smtp($options);
+                $this->_transport[$storeId] = new Smtp($options);
             } else {
-                $this->_transport = new Zend_Mail_Transport_Smtp(
+                $this->_transport[$storeId] = new Zend_Mail_Transport_Smtp(
                     $this->_smtpOptions[$storeId]['host'],
                     $this->_smtpOptions[$storeId]
                 );
             }
         }
 
-        return $this->_transport;
+        return $this->_transport[$storeId];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

There is a bug in the current version of the mail relay module, where if mail is queued for multiple store views, the transport object is created in the first store view and then re-used in the next store view.

This causes intermittent issues for one of our clients where mail would sometimes go out through the wrong mail relay account, causing it to fail DMARC authentication on the DKIM key which is set per account.

This would be triggered both in core Magento, for example in the order emails, and also in any modules which iterate through the store views using store view emulation.

### Description (*)

The function ```getTransport($storeId)``` implies that the transport object will be fetched for that store ID, however the implementation in the function is that the transport object is saved and re-used for next time.

` public function getTransport($storeId)
    {
        if ($this->_transport === null) {`

This has been replaced so that it fetches the specific transport object relating to the store view, with any other instances of the transport variable in the class also being made store view specific.

` public function getTransport($storeId)
    {
        if (!isset($this->_transport[$storeId])) {`
        


### Questions or comments

To replicate the original bug : 

1. Set up a service such as Mailgun with each store view configured to use a different account
2.  Turn off the Magento cron, and make sure email is asynchronous
3. Place orders from 2 different store views
4. Now re-enable the Magento cron.
5. Both emails would have likely gone through the mail relay associated with the first store view.

1. This bug was apparant when using Mailgun across multiple store views
