### PR TITLE
[bugfix] same SMTP configs usage for different stores

### DIFF
--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -70,7 +70,7 @@ class Mail
     protected $_returnPath = [];
 
     /**
-     * @var Zend_Mail_Transport_Smtp
+     * @var  array
      */
     protected $_transport;
 

--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -127,7 +127,7 @@ class Mail
      */
     public function getTransport($storeId)
     {
-        if ($this->_transport === null) {
+        if (empty($this->_transport[$storeId])) {
             if (!isset($this->_smtpOptions[$storeId])) {
                 $configData = $this->smtpHelper->getSmtpConfig('', $storeId);
                 $options    = [
@@ -172,16 +172,16 @@ class Mail
 
                 $options = new SmtpOptions($options);
 
-                $this->_transport = new Smtp($options);
+                $this->_transport[$storeId] = new Smtp($options);
             } else {
-                $this->_transport = new Zend_Mail_Transport_Smtp(
+                $this->_transport[$storeId] = new Zend_Mail_Transport_Smtp(
                     $this->_smtpOptions[$storeId]['host'],
                     $this->_smtpOptions[$storeId]
                 );
             }
         }
 
-        return $this->_transport;
+        return $this->_transport[$storeId];
     }
 
     /**


### PR DESCRIPTION
### Purpose of PR
Fix bugs with the usage of the same transport object (as a result same SMTP configs) for different stores.

### Steps to reproduce
1. Prepare two different websites with different SMTP configs;
2. Place two orders on different websites;
3. Execute email sending for those orders in one PHP process.

#### Expected results
Emails will be sent with corresponding SMTP configs for each website.

#### Actual result
* `First order` is sent correctly.  
* `Second order` in a chain will gonna use SMTP configs from website/store of the `First order` and fail with error:
```
Failed to send email 554 5.2.252 SendAsDenied ***@***.com; not allowed to send as ***@***.com
STOREDRV Submission Exception SendAsDeniedException Map ...
```

### Solution Description
Introduce store-scoped storage for transport object.   
The transport object incapsulates connection configs, connection socket itself and persists connection state.  
For different stores, with different configs, connection configs and connection sockets should be different.

