### PR TITLE
Set Store hostname in SmtpOptions

### DIFF
--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -21,6 +21,7 @@
 
 namespace Mageplaza\Smtp\Mail\Rse;
 
+use Magento\Store\Model\StoreManagerInterface;
 use Mageplaza\Smtp\Helper\Data;
 use Laminas\Mail\Message;
 use Laminas\Mail\Transport\Smtp;
@@ -37,6 +38,11 @@ class Mail
      * @var Data
      */
     protected $smtpHelper;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $_storeManager;
 
     /**
      * @var array Is module enable by store
@@ -82,10 +88,12 @@ class Mail
      * Mail constructor.
      *
      * @param Data $helper
+     * @param StoreManagerInterface $storeManager
      */
-    public function __construct(Data $helper)
+    public function __construct(Data $helper, StoreManagerInterface $storeManager)
     {
         $this->smtpHelper = $helper;
+        $this->_storeManager = $storeManager;
     }
 
     /**
@@ -168,7 +176,8 @@ class Mail
                     unset($options['ssl']);
                 }
                 unset($options['type']);
-
+                $options['name'] = parse_url($this->_storeManager->getStore()->getBaseUrl(), PHP_URL_HOST);
+                
                 $options = new SmtpOptions($options);
 
                 $this->_transport = new Smtp($options);


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
[Laminas SMTP Transport Options](https://docs.laminas.dev/laminas-mail/transport/smtp-options/) has the option to set the name of the local client hostname, this is the name the client uses to identify itself to the mail server (`HELO` command).
The default setting is `localhost`, but some spam filters don't like that (SpamAssassin rule `HELO_LOCALHOST`)

This patch uses the hostname of the website as name in the SmtpOptions.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Send test mail
2. Open the mail headers
3. Before this patch:
   `Received: from localhost (real.host.name [1.2.3.4]) by mx.mail.server;`
4. With this patch:
   `Received: from store.host.name (real.host.name [1.2.3.4]) by mx.mail.server;`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Should this be configurable? Are there situations where this solution is worse than `localhost`?

