### PR TITLE
Fix incorrect field type for `mp_smtp_ace_token`

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -32,7 +32,7 @@
     <constraint xsi:type="foreign" referenceId="MAGEPLAZA_SMTP_ABANDONEDCART_QUOTE_ID_QUOTE_ENTITY_ID" table="mageplaza_smtp_abandonedcart" column="quote_id" referenceTable="quote" referenceColumn="entity_id" onDelete="CASCADE"/>
   </table>
   <table name="quote" resource="default" engine="innodb" comment="quote">
-    <column xsi:type="smallint" name="mp_smtp_ace_token" nullable="true" comment="ACE Token"/>
+    <column xsi:type="varchar" name="mp_smtp_ace_token" nullable="true" length="255" comment="ACE Token"/>
     <column xsi:type="smallint" name="mp_smtp_ace_sent" nullable="true" default="0" comment="ACE Sent"/>
     <column xsi:type="text" name="mp_smtp_ace_log_ids" nullable="true" comment="ACE Log Ids"/>
     <column xsi:type="text" name="mp_smtp_ace_log_data" nullable="true" comment="ACE Log Data"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Field `mp_smtp_ace_token` of the `quote` table currently has type `smallint`, so it can't handle the generated token. It looks like when the code was switching from the setup scripts to the DB Schema approach, the field type was accidentally set incorrectly.

Here we can see that the content that is put into the field should be a string: `\Mageplaza\Smtp\Observer\Quote\SetToken`.

This PR reverts the `mp_smtp_ace_token` field type back to varchar 255.

### Related Pull Requests
No related PR were found.

### Fixed Issues (if relevant)
No open issues were found.

### Manual testing scenarios
1. Open the `quote` table
2. Check the field type
3. Check the data in the column
4. Place an order and make sure that `mp_smtp_ace_token` is generated correctly for your quote

### Questions or comments
No extra questions or comments.
