### PR TITLE
Save exception errors in DB and render in admin modal

### DIFF
--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -139,7 +139,7 @@ class Transport
                 }
                 $this->emailLog($message);
             } catch (Exception $e) {
-                $this->emailLog($message, false);
+                $this->emailLog($message, false, $e->getMessage());
                 throw new MailException(new Phrase($e->getMessage()), $e);
             }
         }
@@ -224,14 +224,15 @@ class Transport
      *
      * @param $message
      * @param bool $status
+     * @param string $error
      */
-    protected function emailLog($message, $status = true)
+    protected function emailLog($message, $status = true, $error = '')
     {
         if ($this->helper->isEnabled($this->_storeId) && $this->resourceMail->isEnableEmailLog($this->_storeId)) {
             /** @var Log $log */
             $log = $this->logFactory->create();
             try {
-                $log->saveLog($message, $status);
+                $log->saveLog($message, $status, $error);
                 if ($status) {
                     $this->saveLogIdForAbandonedCart($log);
                 }

--- a/Model/Log.php
+++ b/Model/Log.php
@@ -98,8 +98,9 @@ class Log extends AbstractModel
      *
      * @param $message
      * @param $status
+     * @param $error
      */
-    public function saveLog($message, $status)
+    public function saveLog($message, $status, $error)
     {
         if ($this->helper->versionCompare('2.2.8')) {
             if ($message->getSubject()) {
@@ -180,6 +181,7 @@ class Log extends AbstractModel
         }
 
         $this->setEmailContent($content)
+            ->setErrorMessage(empty($error) ? null : $error)
             ->setStatus($status)
             ->save();
     }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -4,6 +4,7 @@
     <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true" comment="Log ID"/>
     <column xsi:type="varchar" name="subject" nullable="true" length="255" comment="Email Subject"/>
     <column xsi:type="text" name="email_content" nullable="true" comment="Email Content"/>
+    <column xsi:type="text" name="error_message" nullable="true" comment="Error Message"/>
     <column xsi:type="smallint" name="status" padding="6" unsigned="false" nullable="false" identity="false" comment="Status"/>
     <column xsi:type="timestamp" name="created_at" on_update="false" nullable="true" comment="Created At"/>
     <column xsi:type="varchar" name="from" nullable="true" length="255" comment="Sender" disabled="true"/>

--- a/view/adminhtml/web/js/grid/columns/actions.js
+++ b/view/adminhtml/web/js/grid/columns/actions.js
@@ -46,6 +46,10 @@ define([
                 var row = this.rows[action.rowIndex],
                     modalHtml = '<iframe srcdoc="' + row['email_content'] + '" style="width: 100%; height: 100%"></iframe>';
 
+                if (row['error_message']) {
+                    modalHtml = '<div>' + row['error_message'] + '</div>' + modalHtml;
+                }
+
                 this.modal[action.rowIndex] = $('<div>')
                     .html(modalHtml)
                     .modal({


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR introduces the Transport Exception message saving to the same database table as SMTP logs. By default, an "ERROR" label is displayed in the admin grid if the email fails to send. However, this does not create easy and quick access to view WHY the email failed to send. Digging this in Magento log files becomes tedious very quickly. 

This PR implements the rendering of said error/exception message in the modal popup when the user selects to "View" a specific email log from the actions dropdown.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable SMTP module
2. Configure the SMTP connection incorrectly so that the email fails to send
3. Attempt to send any email; order email, invoice, etc.
