### PR TITLE
Fix to sending test emails.

### DIFF
--- a/view/adminhtml/templates/system/config/button.phtml
+++ b/view/adminhtml/templates/system/config/button.phtml
@@ -29,7 +29,7 @@
 <script type="text/x-magento-init">
     {
         "#smtp_configuration_option_test_email_to": {
-            "mageplaza/testemail": {
+            "Mageplaza_Smtp/js/testemail": {
                 "ajaxUrl": "<?= /* @noEscape */ $block->getButtonUrl() ?>"
             }
         }


### PR DESCRIPTION
Fix to getting "MIME type ('text/plain') is not executable" error on the configuration page in admin and tort beeing able to send test emails.

<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
You aren't able to send test emails in the module configuration and for the ```testemail.js``` file you get the following error:
```because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.```
When you click the Test Now before the fix nothing happens.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Mageplaza->SMTP->Configuration
2. Configure extension and save.
3. On the page go to SMTP Configuration Options->Send Test Email, fill in Send To field and click Test Now.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

