### PR TITLE
Fix main.CRITICAL: Warning: foreach() argument must be of type array|…

### DIFF
--- a/Model/Log.php
+++ b/Model/Log.php
@@ -222,13 +222,13 @@ class Log extends AbstractModel
         $this->setRecipient(implode(',', $toArr));
 
         $ccArr = [];
-        foreach ($message->getCc() as $ccAddr) {
+        foreach ($message->getCc() ?: [] as $ccAddr) {
             $ccArr[] = method_exists($ccAddr, 'getAddress') ? $ccAddr->getAddress() : $ccAddr->getEmail();
         }
         $this->setCc(implode(',', $ccArr));
 
         $bccArr = [];
-        foreach ($message->getBcc() as $bccAddr) {
+        foreach ($message->getBcc() ?: [] as $bccAddr) {
             $bccArr[] = method_exists($bccAddr, 'getAddress') ? $bccAddr->getAddress() : $bccAddr->getEmail();
         }
         $this->setBcc(implode(',', $bccArr));


### PR DESCRIPTION

### Description (*)
Fix main.CRITICAL: Warning: foreach() argument must be of type array|object, null given in www/vendor/mageplaza/module-smtp/Model/Log.php on line 225


### Manual testing scenarios (*)

1. Magento version: 2.4.8 developer mode
2. mageplaza/module-smtp v4.7.18
3. Backend: Customers > select a customer > Customer Edit > Reset Password
4. cat var/log/system.log | grep mageplaz

[2025-08-21T10:16:36.621207+00:00] main.CRITICAL: Warning: foreach() argument must be of type array|object, null given in /home/site/www/vendor/mageplaza/module-smtp/Model/Log.php on line 225 [] []


