### PR TITLE
Remove email validation for username

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -82,7 +82,6 @@
                 </field>
                 <field id="username" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Username</label>
-                    <validate>validate-email</validate>
                 </field>
                 <field id="password" translate="label" type="obscure" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Password</label>


### PR DESCRIPTION

### Description (*)
An SMTP username is not always an email address, so this configuration field should not enforce email validation

### Related Pull Requests
https://github.com/mageplaza/magento-2-smtp/pull/430