### PR TITLE
Cant send test email from admin

### DIFF
--- a/Controller/Adminhtml/Smtp/Test.php
+++ b/Controller/Adminhtml/Smtp/Test.php
@@ -178,6 +178,7 @@ class Test extends Action
                 }
             }
 
+            unset($config['authentication']);
             $this->mailResource->setSmtpOptions($storeId, $config);
 
             $from = $this->senderResolver->resolve(

--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -169,7 +169,7 @@ class Mail
                     $options['connection_config']['ssl'] = $options['ssl'];
                     unset($options['ssl']);
                 }
-                unset($options['type'], $options['authentication']);
+                unset($options['type']);
 
                 $options = new SmtpOptions($options);
 

--- a/Mail/Rse/Mail.php
+++ b/Mail/Rse/Mail.php
@@ -169,7 +169,7 @@ class Mail
                     $options['connection_config']['ssl'] = $options['ssl'];
                     unset($options['ssl']);
                 }
-                unset($options['type']);
+                unset($options['type'], $options['authentication']);
 
                 $options = new SmtpOptions($options);
 


### PR DESCRIPTION
Fixes The option "authentication" does not have a callable "setAuthentication" ("setauthentication") setter method which must be defined when sending test email from admin


'authentication' key is not cleaned up in Test Controller