### PR TITLE
Fix Office 365 email sending on Magento versions < 2.4.8

### DIFF
--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -243,19 +243,19 @@ class Transport
 
         if ($laminasMessage->getCc()) {
             foreach ($laminasMessage->getCc() as $ccAddress) {
-                $email->addCc(new Address($ccAddress->getEmail(), $ccAddress->getName()));
+                $email->addCc(new Address($ccAddress->getEmail(), $ccAddress->getName() ?? ''));
             }
         }
 
         if ($laminasMessage->getBcc()) {
             foreach ($laminasMessage->getBcc() as $bccAddress) {
-                $email->addBcc(new Address($bccAddress->getEmail(), $bccAddress->getName()));
+                $email->addBcc(new Address($bccAddress->getEmail(), $bccAddress->getName() ?? ''));
             }
         }
 
         if ($laminasMessage->getReplyTo()) {
             foreach ($laminasMessage->getReplyTo() as $replyTo) {
-                $email->replyTo(new Address($replyTo->getEmail(), $replyTo->getName()));
+                $email->replyTo(new Address($replyTo->getEmail(), $replyTo->getName() ?? ''));
             }
         }
 
@@ -348,11 +348,7 @@ class Transport
             /** @var Log $log */
             $log = $this->logFactory->create();
             try {
-                if ($this->helper->versionCompare('2.4.8')) {
-                    if ($this->resourceMail->isDeveloperMode($this->_storeId)) {
-                        $message = $this->convertToSymfonyEmail($message);
-                    }
-
+                if ($message instanceof Email) {
                     $log->saveLogSymfony($message, $status, $this->_storeId);
                 } else {
                     $log->saveLog($message, $status, $this->_storeId);

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -23,7 +23,8 @@ namespace Mageplaza\Smtp\Mail;
 
 use Closure;
 use Exception;
-use Laminas\Mail\Message;
+use Laminas\Mime\Message as LaminasMimeMessage;
+use Laminas\Mime\Mime as LaminasMime;
 use Magento\Framework\Exception\MailException;
 use Magento\Framework\Mail\EmailMessage;
 use Magento\Framework\Mail\TransportInterface;
@@ -235,6 +236,23 @@ class Transport
                 }
                 if ($part instanceof DataPart) {
                     $email->addPart($part);
+                }
+            }
+        } elseif ($body instanceof LaminasMimeMessage) {
+            foreach ($body->getParts() as $part) {
+                $content = $part->getRawContent();
+                if ($part->getType() === LaminasMime::TYPE_HTML) {
+                    $email->html($content, $part->getCharset());
+
+                } elseif ($part->getType() === LaminasMime::TYPE_TEXT) {
+                    $email->text($content, $part->getCharset());
+                }
+
+                //Handle attachments
+                if (isset($part->disposition) && !empty($part->getDisposition())) {
+                    $dataPart = new DataPart($part->getContent(), $part->getFileName(), $part->getEncoding());
+                    $dataPart->setDisposition($part->getDisposition());
+                    $email->addPart($dataPart);
                 }
             }
         } else {

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -250,7 +250,7 @@ class Transport
 
                 //Handle attachments
                 if (isset($part->disposition) && !empty($part->getDisposition())) {
-                    $dataPart = new DataPart($part->getContent(), $part->getFileName(), $part->getEncoding());
+                    $dataPart = new DataPart($part->getContent(), isset($part->filename) ? $part->getFileName() : null, $part->getEncoding());
                     $dataPart->setDisposition($part->getDisposition());
                     $email->addPart($dataPart);
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
There is an issue sending emails on versions of Magento below 2.4.8. There are 3 issues this PR addresses:

1. In `Mail/Transport.php` in `convertToSymfonyEmail` which handles the conversion of a Laminas message (Magento's previous implementation of `TransportInterface`) to a Symfony message. In versions > 2.4.8, this function is never called because `getMessage` returns a Symfony message when `$transport->getMessage()` is called (since this is the implementation of `TransportInterface`). However in versions before Magento 2.4.8, where Laminas messages are the implementation of `TransportInterface` the `convertToSymfonyEmail` is called because `getMessage` will return a Laminas message. When building the Symfony message, the Cc, Bcc and Reply-To addresses are added, however in the constructor for `Symfony\Component\Mime\Address` the `$name` param is not nullable, whereas in the Laminas implementation it is. Potential null values are not handled, so this PR null coalesces the `getName` function to ensure an empty string is passed in if the value is `null`.
2. With the new OAuth authentication method for Office365, emails are sent via GraphQL. To do this, the message is converted to a Symfony message. However, the `emailLog` method only checks the Magento version when it determines which `saveLog` method it should use. Since it's possible for the message to have been converted to a Symfony message on versions < 2.4.8, the correct approach would be to check the type.
3. `convertToSymfonyEmail` only handles conversion of the message body when the type passed into the method is already a Symfony type. This doesn't make any sense, because if it were already a Symfony type, there would be no reason to convert it. This PR adds an additional condition to handle conversion of a message body from Laminas message type. As per [Laminas's documentation ](https://docs.laminas.dev/laminas-mail/message/attachments/#adding-attachments) there is no convenient way to handle attachments, but we can use the `Laminas\Mime\Part` from the `Laminas\Mime\Message` and check whether it has disposition to determine if it's a file, and then build a Symfony `DataPart` using that information.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
n/a

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios (*)
1. On a Magento version prior to 2.4.8 configure the module to send using Office 365 as the provider.
2. Send any sort of email other than the test email (customer password reset, order confirmation)
4. An exception will be thrown in the exception log, no email will be sent, and no email log will be saved

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

