### PR TITLE
Add turboSMTP provider preset and allow non-email SMTP usernames

### DIFF
--- a/Block/Adminhtml/System/Config/Host.php
+++ b/Block/Adminhtml/System/Config/Host.php
@@ -264,6 +264,27 @@ class Host extends Field
                     'protocol' => 'tls'
                 ]
             ],
+            'turbosmtp'   => [
+                'label' => __('turboSMTP'),
+                'info'  => [
+                    'global' => [
+                        'label' => __('Global'),
+                        'info'  => [
+                            'host'     => 'pro.turbo-smtp.com',
+                            'port'     => '465',
+                            'protocol' => 'ssl'
+                        ]
+                    ],
+                    'eu'     => [
+                        'label' => __('EU'),
+                        'info'  => [
+                            'host'     => 'pro.eu.turbo-smtp.com',
+                            'port'     => '465',
+                            'protocol' => 'ssl'
+                        ]
+                    ]
+                ]
+            ],
             'aol'         => [
                 'label' => __('AOL Mail'),
                 'info'  => [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -83,7 +83,6 @@
                 </field>
                 <field id="username" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Username</label>
-                    <validate>validate-email</validate>
                 </field>
                 <field id="password" translate="label" type="obscure" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Password</label>


### PR DESCRIPTION
### Description (*)

This adds turboSMTP (https://serversmtp.com) to the pre-defined SMTP provider
list so it can be selected with the "Load Settings" picker. It is added with both
regional endpoints, mirroring the nested region structure already used for Amazon
SES:

* Global: `pro.turbo-smtp.com`
* EU: `pro.eu.turbo-smtp.com`

Both use port `465` with the `SSL` protocol.

While testing the preset I hit a second problem that makes turboSMTP impossible to
finish configuring from the UI: the **Username** field enforces `validate-email`,
but turboSMTP's SMTP username is the account **Consumer Key** (a hex string), not
an email address, so "Save Config" is rejected with "Please enter a valid email
address". The same rule already blocks other providers whose username is not an
email address: SendGrid uses the literal `apikey`, Amazon SES uses a generated IAM
SMTP user, Mailjet uses an API key, Postmark uses a server token. Because the field
legitimately holds a username **or** an API credential, the email-format rule is
incorrect for it.

Changes:

1. `Block/Adminhtml/System/Config/Host.php`: add the `turbosmtp` entry to
   `getOptionProvider()` with the Global and EU endpoints.
2. `etc/adminhtml/system.xml`: remove `validate-email` from the SMTP **Username**
   field. The **Return-Path Email** field keeps `validate-email`, since that one is
   genuinely an address.

No existing configuration is affected. An invalid username still fails with a clear
SMTP authentication error, exactly as before.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

Not linked to an issue. The Username change also unblocks configuring SendGrid,
Amazon SES, Mailjet and Postmark from the UI, since all of those use a non-email
SMTP username.

### Manual testing scenarios (*)

Tested on Magento Open Source 2.4.7 (PHP 8.3).

1. Go to Stores > Configuration > Mageplaza Extensions > SMTP and open the
   **SMTP Configuration Options** group.
2. Click **Load Settings** next to Host, scroll to **turboSMTP**, expand it, choose
   **EU**, and click its **Load Settings**. The form fills Host `pro.eu.turbo-smtp.com`,
   Port `465`, Protocol `SSL`. (Choosing **Global** fills `pro.turbo-smtp.com`.)
3. Set **Authentication** to `LOGIN`, enter the turboSMTP **Consumer Key** as
   **Username** and the **Consumer Secret** as **Password**.
4. Click **Save Config**. Before this change the save is blocked with "Please enter
   a valid email address"; after it, the configuration saves.
5. Expand **Send Test Email**, enter a recipient, and click **Test Now**. The test
   email is delivered through turboSMTP ("Sent successfully").

### Screenshots

turboSMTP in the provider picker:

![turboSMTP in provider picker](https://raw.githubusercontent.com/NewtTheWolf/magento-2-smtp/pr-assets/assets/1-turbosmtp-in-provider-picker.png)

Global and EU endpoints:

![Global and EU endpoints](https://raw.githubusercontent.com/NewtTheWolf/magento-2-smtp/pr-assets/assets/2-global-and-eu-endpoints.png)

EU "Load Settings" fills Host / Port / Protocol:

![EU Load Settings fills fields](https://raw.githubusercontent.com/NewtTheWolf/magento-2-smtp/pr-assets/assets/3-eu-loadsettings-fills-fields.png)

Configuration saved with the Consumer Key as Username:

![Saved with Consumer Key](https://raw.githubusercontent.com/NewtTheWolf/magento-2-smtp/pr-assets/assets/4-saved-with-consumer-key.png)

Test email sent:

![Test email sent successfully](https://raw.githubusercontent.com/NewtTheWolf/magento-2-smtp/pr-assets/assets/5-test-email-sent-successfully.png)

Test email received (delivered through turboSMTP):

![Email received](https://raw.githubusercontent.com/NewtTheWolf/magento-2-smtp/pr-assets/assets/6-email-received-from-spitzli.png)

### Questions or comments

If you would rather review the two changes separately, I am happy to split the
Username validation fix into its own PR and keep this one to the turboSMTP preset.
